### PR TITLE
Improve benchmarking episode

### DIFF
--- a/_episodes/02-benchmarking.md
+++ b/_episodes/02-benchmarking.md
@@ -63,8 +63,34 @@ pip install memory_profiler
 ~~~
 {: .source}
 
-FIXME: workout example in Jupyter, see gh:nlesc/noodles notebook
+In Jupyter, type the following lines to compare the memory usage of the serial and parallel versions of the code presented above:
+~~~python
+import numpy as np
+import dask.array as da
+from memory_profiler import memory_usage
+import matplotlib.pyplot as plt
 
+def sum_with_numpy():
+    # Serial implementation
+    np.arange(10**8).sum()
+
+def sum_with_dask():
+    # Parallel implementation
+    work = da.arange(10**8).sum()
+    work.compute()
+
+memory_numpy = memory_usage(sum_with_numpy, interval=0.01)
+memory_dask = memory_usage(sum_with_dask, interval=0.01)
+
+# Plot results
+plt.plot(memory_numpy, label='numpy')
+plt.plot(memory_dask, label='dask')
+plt.xlabel('Time step')
+plt.ylabel('Memory / MB')
+plt.legend()
+plt.show()
+~~~
+{: .source}
 
 # Alternate Profiling
 

--- a/_episodes/02-benchmarking.md
+++ b/_episodes/02-benchmarking.md
@@ -94,7 +94,7 @@ plt.show()
 
 # Alternate Profiling
 
-Dask has a couple of rofiling options as well
+Dask has a couple of profiling options as well
 
 ~~~python
 from dask.diagnostics import Profiler, ResourceProfiler

--- a/_episodes/02-benchmarking.md
+++ b/_episodes/02-benchmarking.md
@@ -125,7 +125,13 @@ lscpu
 ~~~
 {: .source}
 
-FIXME: add respective commands on Windows and Mac
+On Mac:
+~~~bash
+sysctl -n hw.physicalcpu
+~~~
+{: .source}
+
+FIXME: add respective commands on Windows
 
 On a machine with 8 listed cores doing this (admittedly oversimplistic) benchmark:
 

--- a/_episodes/02-benchmarking.md
+++ b/_episodes/02-benchmarking.md
@@ -24,13 +24,13 @@ your system monitor, and run the following:
 
 ~~~python
 import numpy as np
-result = np.arange(10**8).sum()
+result = np.arange(10**9).sum()
 ~~~
 {: .source}
 
 ~~~python
 import dask.array as da
-work = da.arange(10**8).sum()
+work = da.arange(10**9).sum()
 result = work.compute()
 ~~~
 {: .source}
@@ -41,7 +41,7 @@ How can we test in a more rigorous way? In Jupyter we can use some line magics!
 
 ~~~python
 %%time
-np.arange(10**8).sum()
+np.arange(10**9).sum()
 ~~~
 {: .source}
 
@@ -49,7 +49,7 @@ This was only a single run, how can we trust this?
 
 ~~~python
 %%timeit
-np.arange(10**8).sum()
+np.arange(10**9).sum()
 ~~~
 {: .source}
 
@@ -72,11 +72,11 @@ import matplotlib.pyplot as plt
 
 def sum_with_numpy():
     # Serial implementation
-    np.arange(10**8).sum()
+    np.arange(10**9).sum()
 
 def sum_with_dask():
     # Parallel implementation
-    work = da.arange(10**8).sum()
+    work = da.arange(10**9).sum()
     work.compute()
 
 memory_numpy = memory_usage(sum_with_numpy, interval=0.01)
@@ -98,7 +98,7 @@ Dask has a couple of profiling options as well
 
 ~~~python
 from dask.diagnostics import Profiler, ResourceProfiler
-work = da.arange(10**8).sum()
+work = da.arange(10**9).sum()
 with Profiler() as prof, ResourceProfiler(dt=0.001) as rprof:
     result2 = work.compute()
 
@@ -111,7 +111,7 @@ FIXME: somehow the visualisation turns up in a separate file and in the notebook
 
 ~~~python
 with ResourceProfiler(dt=0.001) as rprof2:
-    result = np.arange(10**8).sum()
+    result = np.arange(10**9).sum()
 visualize([rprof2], output_notebook())
 ~~~
 FIXME: without the Profiler, the time axis is not nicely scaled. Profiler does not work with dask commands.

--- a/_episodes/02-benchmarking.md
+++ b/_episodes/02-benchmarking.md
@@ -24,13 +24,13 @@ your system monitor, and run the following:
 
 ~~~python
 import numpy as np
-result = np.arange(10**9).sum()
+result = np.arange(10**7).sum()
 ~~~
 {: .source}
 
 ~~~python
 import dask.array as da
-work = da.arange(10**9).sum()
+work = da.arange(10**7).sum()
 result = work.compute()
 ~~~
 {: .source}
@@ -41,7 +41,7 @@ How can we test in a more rigorous way? In Jupyter we can use some line magics!
 
 ~~~python
 %%time
-np.arange(10**9).sum()
+np.arange(10**7).sum()
 ~~~
 {: .source}
 
@@ -49,7 +49,7 @@ This was only a single run, how can we trust this?
 
 ~~~python
 %%timeit
-np.arange(10**9).sum()
+np.arange(10**7).sum()
 ~~~
 {: .source}
 
@@ -72,11 +72,11 @@ import matplotlib.pyplot as plt
 
 def sum_with_numpy():
     # Serial implementation
-    np.arange(10**9).sum()
+    np.arange(10**7).sum()
 
 def sum_with_dask():
     # Parallel implementation
-    work = da.arange(10**9).sum()
+    work = da.arange(10**7).sum()
     work.compute()
 
 memory_numpy = memory_usage(sum_with_numpy, interval=0.01)
@@ -98,7 +98,7 @@ Dask has a couple of profiling options as well
 
 ~~~python
 from dask.diagnostics import Profiler, ResourceProfiler
-work = da.arange(10**9).sum()
+work = da.arange(10**7).sum()
 with Profiler() as prof, ResourceProfiler(dt=0.001) as rprof:
     result2 = work.compute()
 
@@ -111,7 +111,7 @@ FIXME: somehow the visualisation turns up in a separate file and in the notebook
 
 ~~~python
 with ResourceProfiler(dt=0.001) as rprof2:
-    result = np.arange(10**9).sum()
+    result = np.arange(10**7).sum()
 visualize([rprof2], output_notebook())
 ~~~
 FIXME: without the Profiler, the time axis is not nicely scaled. Profiler does not work with dask commands.
@@ -138,7 +138,7 @@ On a machine with 8 listed cores doing this (admittedly oversimplistic) benchmar
 ~~~python
 import timeit
 x = [timeit.timeit(
-        stmt=f"da.arange(5*10**9).sum().compute(num_workers={n})",
+        stmt=f"da.arange(5*10**7).sum().compute(num_workers={n})",
         setup="import dask.array as da",
         number=1)
      for n in range(1, 9)]


### PR DESCRIPTION
I have added a piece of code that uses `memory_profiler` to check the memory usage of the serial and parallel codes, plus other minor changes.